### PR TITLE
fix: fix import path for server

### DIFF
--- a/lua/live-preview/server/init.lua
+++ b/lua/live-preview/server/init.lua
@@ -3,5 +3,5 @@
 local M = {}
 M.handler = require('live-preview.server.handler')
 M.utils = require('live-preview.server.utils')
-M.Server = require('lua.live-preview.server.server')
+M.Server = require('live-preview.server.server')
 return M


### PR DESCRIPTION
`require('lua.live-preview.server.server')` will try to import from the user's config and error out as the file is not found.

Changed the import path to import from the internal path instead of the user config.