### PR TITLE
fix(picker): telescope dependency check

### DIFF
--- a/lua/livepreview/picker.lua
+++ b/lua/livepreview/picker.lua
@@ -81,7 +81,7 @@ end
 ---This function will try to use telescope.nvim, fzf-lua, or mini.pick to open a picker to select a file.
 ---@param callback function: Callback function to run after selecting a file
 function M.pick(callback)
-	if pcall(require, "telescope._extensions.livepreview") then
+	if pcall(require, "telescope") then
 		M.telescope(callback)
 	elseif pcall(require, "fzf-lua") then
 		M.fzflua(callback)


### PR DESCRIPTION
Was testing out the picker functionality and found it odd that I was being told I didn't have telescope installed. Sure enough, I found the check in the code was requiring an extension.

Because I could not find the extension mentioned anywhere in the readme, I decided to remove it and just run the check against telescope on it's own instead. This worked just fine :)