### PR TITLE
fix(cmd): resolve windows compatibility issues for path operations

### DIFF
--- a/lua/livepreview/init.lua
+++ b/lua/livepreview/init.lua
@@ -124,7 +124,7 @@ function M.setup(opts)
 			local filepath
 			if cmd_opts.fargs[2] ~= nil then
 				filepath = cmd_opts.fargs[2]
-				if vim.fn.isabsolutepath(filepath) == 0 then
+				if not utils.is_absolute(filepath) then
 					filepath = utils.joinpath(vim.uv.cwd(), filepath)
 				end
 			else
@@ -137,12 +137,13 @@ function M.setup(opts)
 					end
 				end
 			end
+			filepath = vim.fs.normalize(filepath)
 			utils.open_browser(
 				string.format(
 					"http://localhost:%d/%s",
 					config.config.port,
 					config.config.dynamic_root and vim.fs.basename(filepath)
-						or utils.get_base_path(filepath, vim.uv.cwd())
+						or utils.get_base_path(filepath, vim.fs.normalize(vim.uv.cwd() or ""))
 				),
 				config.config.browser
 			)

--- a/lua/livepreview/utils.lua
+++ b/lua/livepreview/utils.lua
@@ -362,4 +362,11 @@ function M.kill(pid)
 	vim.uv.kill(pid, 9) -- 9 is the signal number for SIGKILL
 end
 
+--- Check if a path is absolute
+--- @param path string
+--- @return boolean
+function M.is_absolute(path)
+	return path:sub(1, 1) == "/" or path:sub(2, 2) == ":"
+end
+
 return M


### PR DESCRIPTION
Fixes two issues that appear to be isolated to the Windows platform:

1. The windows build of neovim doesn't have `vim.fn.isabsolutepath` so I've implemented a new util function to handle this.
2. Windows paths in neovim often mix both forward and backwards slashes. This was causing some problems with calculating the URL. I've added a step to `utils.get_base_path` that normalises all paths before attempting to manipulate them.

Let me know if you have any questions :)