### PR TITLE
fix(windows): auto-detect pwsh/powershell (Fixes #301)

### DIFF
--- a/lua/livepreview/utils.lua
+++ b/lua/livepreview/utils.lua
@@ -125,6 +125,10 @@ function M.isWindows()
 	return vim.uv.os_uname().version:match("Windows")
 end
 
+---@type pwsh|powershell
+local powershell_cmd = vim.fn.executable("pwsh") == 1 and "pwsh" 
+	or "powershell"
+
 --- Execute a shell commands
 ---@async
 ---@param cmd string: terminal command to execute. Term_cmd will use sh or pwsh depending on the OS
@@ -136,7 +140,7 @@ end
 function M.term_cmd(cmd, callback)
 	local shell = "sh"
 	if M.isWindows() then
-		shell = "pwsh"
+		shell = powershell_cmd
 	end
 
 	local on_exit = function(result)
@@ -158,7 +162,7 @@ end
 function M.await_term_cmd(cmd)
 	local shell = "sh"
 	if M.isWindows() then
-		shell = "pwsh"
+		shell = powershell_cmd
 	end
 	local results = vim.system({ shell, "-c", cmd }, { text = true }):wait()
 	return results


### PR DESCRIPTION
## Issue

The default shell command selection for windows was simply `"pwsh"`, as this is only applicable for Powershell Core (6/7) shipped with Windows 11, it is not applicable for Windows 10, as it usually ships with Powershell 5.1, which does not have the `pwsh` command built-in, and instead launches with the command `powershell`.

**Fixes #301**

## Fix

Changed the windows shell selection part of `utils.term_cmd` & `utils.await_term_cmd` to use a new picker function `pick_powershell()`, that determines which command vim detects is available with `vim.fn.executable()`, with a preference towards the newer `pwsh`, and a fallback to `powershell`.

## Testing

I do not have a Windows 11 machine or VM, so only tested on a Windows 10 machine, but the error mentioned in #301 no longer occurs with the new changes, and `:LivePreview start` works as expected. No changes to previous functionality for windows users should occur besides adding support for Windows 10, thus I expect everything should work fine on a Windows 11 machine.

*Happy to tweak based on feedback!*