### PR TITLE
fix(open_browser): make it work for `browser="default"`

### DIFF
--- a/lua/livepreview/utils.lua
+++ b/lua/livepreview/utils.lua
@@ -269,13 +269,10 @@ end
 --- @param path string
 --- @param browser string|nil
 function M.open_browser(path, browser)
-	path = vim.fn.shellescape(path) or nil
-	if path then
-		if browser == "default" or browser == nil or #browser == 0 then
-			vim.ui.open(path)
-		else
-			M.term_cmd(browser .. " " .. path)
-		end
+	if browser == "default" or browser == nil or #browser == 0 then
+		vim.ui.open(path)
+	else
+		M.term_cmd(browser .. " " .. vim.fn.shellescape(path))
 	end
 end
 


### PR DESCRIPTION
Passing the value from `vim.fn.shellescape` to `vim.ui.open` breaks the latter (nothing happens), `vim.ui.open` can handle spaces in path itself.

I also don't think there's a need for `or nil` in case of `vim.fn.shellescape`, but I might be wrong here.