### PR TITLE
fix(Fixing luacheck errors)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,3 +24,7 @@ ignore = {
 read_globals = { "vim" }
 
 exclude_files = {}
+
+globals = {
+	"LivePreview",
+}

--- a/lua/livepreview/utils.lua
+++ b/lua/livepreview/utils.lua
@@ -34,7 +34,7 @@ end
 ---@param file_name string
 ---@return string|nil
 function M.supported_filetype(file_name)
-	local file_name = file_name or ""
+	file_name = file_name or ""
 	if file_name:match("%.html$") then
 		return "html"
 	elseif file_name:match("%.md$") or file_name:match("%.markdown$") then

--- a/plugin/livepreview.lua
+++ b/plugin/livepreview.lua
@@ -94,9 +94,8 @@ end, {
 
 local config = require("livepreview.config")
 --- Public API
-LivePreview = {
-	config = vim.deepcopy(config.default),
-}
+LivePreview = {}
+LivePreview.config = vim.deepcopy(config.default)
 
 setmetatable(LivePreview.config, {
 	__index = function(_, key)


### PR DESCRIPTION
Adding `LivePreview` as a global for luacheck to track
Removing unnecesary `local` modifier

This doesnt change the scope of the `LivePreview` variable, as done in previous bad pull request.
Finally removing the `local` modifier for a parameter check, as it masks the parameter with a new local variable.