### PR TITLE
Update utils.lua with $procID instead of $pid

### DIFF
--- a/lua/livepreview/utils.lua
+++ b/lua/livepreview/utils.lua
@@ -284,10 +284,10 @@ function M.processes_listening_on_port(port)
 	if vim.uv.os_uname().version:match("Windows") then
 		cmd = ([[
 			Get-NetTCPConnection -LocalPort %d | Where-Object { $_.State -eq 'Listen' } | ForEach-Object {
-				$pid = $_.OwningProcess
-				$process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+				$procID = $_.OwningProcess
+				$process = Get-Process -Id $procID -ErrorAction SilentlyContinue
 				if ($process) {
-					$process.Name + " " + $pid
+					$process.Name + " " + $procID
 				}
 			}
 			]]):format(port)


### PR DESCRIPTION
Fixes the `Cannot overwrite variable PID because it is read-only or constant.` errors in newer powershell versions. This was due to $PID being used internally by pwsh.