### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Plug 'brianhuster/live-preview.nvim'
 Plug 'nvim-telescope/telescope.nvim'
 Plug 'ibhagwan/fzf-lua'
 Plug 'echasnovski/mini.pick'
-Plog 'folke/snacks.nvim'
+Plug 'folke/snacks.nvim'
 ```
 
 </details>


### PR DESCRIPTION
Under the vim-plug section, a 'Plug' entry is typed as 'Plog'. I fixed this typo.