### PR TITLE
fix: `>` shows up as `&gt;` in code blocks

### DIFF
--- a/static/markdown/main.js
+++ b/static/markdown/main.js
@@ -21,7 +21,7 @@ const livepreview_render = (text) => {
 	hljs.highlightAll();
 }
 
-const markdownText = document.querySelector('.markdown-body').innerHTML;
+const markdownText = document.querySelector('.markdown-body').textContent;
 livepreview_render(markdownText);
 
 


### PR DESCRIPTION
Open a markdown file with `>` in a code block, for example
````md
```
2 > 1
```
````

and run `LivePreview start`, it is rendered as
```html
<code data-highlighted="yes" class="hljs language-markdown">2 <span class="hljs-literal">&amp;gt;</span> 1
</code>
```

And in the browser I see `2 &gt; 1` rendered in a code block. But I should be seeing `2 > 1` since that's the actual text in the markdown file.

This seems to be a pretty basic use case so please let me know anything I missed or if it's expected.