### PR TITLE
fix: isRightPath function for Windows users

### DIFF
--- a/static/ws-client.js
+++ b/static/ws-client.js
@@ -9,14 +9,30 @@ function getWebSocketUrl() {
 	return `${protocol}//${hostname}${port}`;
 }
 
-/** 
+/**
+ * Normalize Windows file path to use forward slashes
+ * @param {string} filepath - The file path to normalize
+ * @returns {string} - The normalized file path
+ */
+const normalizePath = (filepath) => {
+    if (!filepath) return '';
+
+    const isWindows = /^[a-zA-Z]:\\/.test(filepath) ||
+                      filepath.startsWith('\\\\');
+
+    return isWindows ? filepath.replace(/\\/g, '/') : filepath;
+};
+
+/**
  * Check if browser should handle websocket message from server
  * @param {string} filepath - The path of the file
  * @returns {boolean} - True if the browser should handle the message, false otherwise
  */
 const isRightPath = (filepath) => {
-	return filepath.includes(window.location.pathname.replace(/%20/g, " "));
-}
+	console.log("Checking path:", filepath, "against", window.location.pathname);
+    const normalized = normalizePath(filepath);
+    return normalized.endsWith(window.location.pathname);
+};
 
 let livepreview_reload
 


### PR DESCRIPTION
The browser could not refresh the page due to the Windows file paths.