### PR TITLE
fix: remove redundant check_config() call

### DIFF
--- a/lua/livepreview/health.lua
+++ b/lua/livepreview/health.lua
@@ -95,8 +95,6 @@ local function check_config()
 	info("Your configuration table >lua\n" .. vim.inspect(config))
 end
 
-check_config()
-
 --- Run checkhealth for Live Preview. This can also be called using `:checkhealth livepreview`
 function M.check()
 	local health = vim.health


### PR DESCRIPTION
I was inspecting my `--startuptime` neovim output and I noticed that `live-preview.nvim` was causing `vim.health` to load during startup, this function call was the cause