### PR TITLE
fix: KaTeX block equations not rendering on initial page load

### DIFF
--- a/lua/livepreview/template.lua
+++ b/lua/livepreview/template.lua
@@ -12,7 +12,7 @@ local html_template = function(body, stylesheet, script_tag)
 ]] .. stylesheet .. [[
             <link rel="stylesheet" href="/live-preview.nvim/static/katex/katex.min.css">	
             <script defer src="/live-preview.nvim/static/katex/katex.min.js"></script>
-			<script defer src="/live-preview.nvim/static/katex/auto-render.min.js" onload="renderMathInElement(document.body);"></script>
+			<script defer src="/live-preview.nvim/static/katex/auto-render.min.js"></script>
             <script src="/live-preview.nvim/static/mermaid/mermaid.min.js"></script>
 			<link rel="stylesheet" href="/live-preview.nvim/static/highlight/main.css">
 			<script defer src="/live-preview.nvim/static/highlight/highlight.min.js"></script>

--- a/tests/test with space.md
+++ b/tests/test with space.md
@@ -1,7 +1,12 @@
 # like to contribute to this project, please feel free to open an issue
-    $E = mc^2$
 
-```mermaid 
+$E = mc^2$
+
+$$ a(t) = \frac{d^2x(t)}{dt^2} $$
+
+$$ x(t) = \int \int a(t) \ dt^2 $$
+
+```mermaid
 graph TD;
     A-->B;
     A-->C;


### PR DESCRIPTION
Hi hi,

KaTeX block equations (`$$...$$`) are not being rendered when the live preview is initially opened in the browser. However, they start rendering correctly as soon as the file is edited.

Apparently there's a race condition in the script loading order.
1. The `onload="renderMathInElement(document. body);` handler runs with default KaTeX delimiters before the main.js loads the delimiters.
2. When the file is edited, the update handler calls livepreview_renderKatex() from main.js fixing the rendering.

**Before**
<img width="1022" height="263" alt="image" src="https://github.com/user-attachments/assets/d1488ac1-9021-49c0-a4c0-485b90b60c16" />
**After**
<img width="1035" height="276" alt="image" src="https://github.com/user-attachments/assets/cc754cb0-089e-4de9-9661-bff95bbaf970" />


_Huge disclamer: I'm not a JS expert_