### PR TITLE
fix: don't let markdown-it handle Katex block

### DIFF
--- a/static/markdown/main.js
+++ b/static/markdown/main.js
@@ -10,6 +10,69 @@ const md = window.markdownit({
 		return ''; // use external default escaping
 	}
 });
+
+function math_block(state, startLine, endLine, silent) {
+  var firstLine, lastLine, lastPos, found = false,
+      pos = state.bMarks[startLine] + state.tShift[startLine],
+      max = state.eMarks[startLine];
+
+  if (pos + 2 > max) { return false; }
+  if (state.src.slice(pos, pos + 2) !== '$$') { return false; }
+
+  pos += 2;
+  firstLine = state.src.slice(pos, max);
+
+  if (silent) { return true; }
+  if (firstLine.trim().slice(-2) === '$$') {
+    // Single line expression
+    firstLine = firstLine.trim().slice(0, -2);
+    found = true;
+  }
+
+  for (var nextLine = startLine; !found; ) {
+
+    nextLine++;
+
+    if (nextLine >= endLine) { break; }
+
+    pos = state.bMarks[nextLine] + state.tShift[nextLine];
+    max = state.eMarks[nextLine];
+
+    if (pos < max && state.tShift[nextLine] < state.blkIndent) {
+      // non-empty line with negative indent should stop the list:
+      break;
+    }
+
+    if (state.src.slice(pos, max).trim().indexOf('$$') !== -1) {
+      lastPos = state.src.slice(0, max).lastIndexOf('$$');
+      lastLine = state.src.slice(pos, lastPos);
+      found = true;
+    }
+  }
+
+  state.line = nextLine + 1;
+
+  var token = state.push('math_block', 'math', 0);
+  token.block = true;
+  if (firstLine.trim().slice(-2) === '$$') {
+    token.content = firstLine;
+  } else {
+    token.content = state.getLines(startLine, nextLine + 1, state.tShift[startLine], true)
+      .replace(/^\s*\$\$\s*|\s*\$\$\s*$/g, '');
+  }
+  token.map = [ startLine, state.line ];
+  token.markup = '$$';
+  return true;
+}
+
+md.block.ruler.before('fence', 'math_block', math_block, {
+    alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
+});
+
+md.renderer.rules.math_block = (tokens, idx) => {
+    return '$$' + tokens[idx].content + '$$';
+};
+
 md.use(livepreview_injectLinenumbersPlugin);
 
 md.use(markdownitEmoji);
@@ -23,5 +86,3 @@ const livepreview_render = (text) => {
 
 const markdownText = document.querySelector('.markdown-body').textContent;
 livepreview_render(markdownText);
-
-

--- a/tests/test with space.md
+++ b/tests/test with space.md
@@ -1,10 +1,12 @@
 # like to contribute to this project, please feel free to open an issue
 
 $E = mc^2$
-
-$$ a(t) = \frac{d^2x(t)}{dt^2} $$
-
-$$ x(t) = \int \int a(t) \ dt^2 $$
+$$
+\begin{cases}
+r_{i,k} &=& \Phi_i + (k-1)T_i \\
+d_{i,k} &=& r_{i,k} + D_i
+\end{cases}
+$$
 
 ```mermaid
 graph TD;


### PR DESCRIPTION
Problem:
- Currently, you need to escape special characters like `\` in Katex blocks when using markdown-it.

TODO: should replace auto-render.js