### PR TITLE
feat: auto-detect dark/light theme for Mermaid diagrams

### DIFF
--- a/static/mermaid/main.js
+++ b/static/mermaid/main.js
@@ -4,12 +4,21 @@ function livepreview_renderMermaid() {
 	});
 }
 
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
 mermaid.initialize({
 	startOnLoad: false,
 	securityLevel: 'loose',
-	theme: 'neutral',
+	theme: prefersDark ? 'dark' : 'default',
 });
 
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+	mermaid.initialize({
+		startOnLoad: false,
+		securityLevel: 'loose',
+		theme: e.matches ? 'dark' : 'default',
+	});
+	livepreview_renderMermaid();
+});
 
 livepreview_renderMermaid();
-


### PR DESCRIPTION
## Summary
Automatically switch Mermaid theme based on OS/browser color scheme preference using `prefers-color-scheme` media query.

## Problem
The current hardcoded `neutral` theme makes Mermaid diagrams difficult to read for users with dark mode enabled.

## Solution
- Detect system color scheme preference at load time
- Use `dark` theme for dark mode, `default` theme for light mode
- Listen for theme changes and dynamically re-render diagrams

## Testing
Tested with macOS dark mode and live-preview.nvim. Diagrams now render with appropriate colors for both light and dark themes.