### PR TITLE
fix: make Server:new return a new instance instead of mutating the class

### DIFF
--- a/lua/livepreview/server/init.lua
+++ b/lua/livepreview/server/init.lua
@@ -64,6 +64,7 @@ end
 --- Constructor
 --- @param webroot string|nil: path to the webroot
 function Server:new(webroot)
+	self = setmetatable({}, Server)
 	self.server = uv.new_tcp()
 	self.webroot = webroot or uv.cwd()
 	api.nvim_create_augroup("LivePreview", {


### PR DESCRIPTION
`Server:new` writes `self.server`/`self.webroot` straight onto the `Server` class table and returns it, so every call hands back the same singleton. On consecutive starts (`:LivePreview start` then `:LivePreview pick`), the old instance's deferred close callback nils `self.server` after the new server has already taken that slot, and the next connection crashes at `self.server:accept(client)`. Instantiating a fresh table in the constructor, the way `Watcher:new` already does, keeps each server isolated. Fixes #367.