### PR TITLE
feat: support port=0 for auto-assign free port

### DIFF
--- a/lua/livepreview/init.lua
+++ b/lua/livepreview/init.lua
@@ -30,23 +30,21 @@ end
 ---@param port number: port to run the server on
 ---@return boolean?
 function M.start(filepath, port)
-	local processes = utils.processes_listening_on_port(port)
-	if #processes > 0 then
-		for _, process in ipairs(processes) do
-			if process.pid ~= vim.uv.os_getpid() then
-				-- local kill_confirm = vim.fn.confirm(
-				-- 	("Port %d is being listened by another process `%s` (PID %d). Kill it?"):format(port, process.name, process.pid),
-				-- 	"&Yes\n&No", 2)
-				-- if kill_confirm ~= 1 then return else utils.kill(process.pid) end
-				vim.notify(
-					("Port %d is being used by another process `%s` (PID %d). Run `:lua vim.uv.kill(%d)` to kill it or change the port with `:lua LivePreview.config.port = <new_port>`"):format(
-						port,
-						process.name,
-						process.pid,
-						process.pid
-					),
-					vim.log.levels.WARN
-				)
+	if port ~= 0 then
+		local processes = utils.processes_listening_on_port(port)
+		if #processes > 0 then
+			for _, process in ipairs(processes) do
+				if process.pid ~= vim.uv.os_getpid() then
+					vim.notify(
+						("Port %d is being used by another process `%s` (PID %d). Run `:lua vim.uv.kill(%d)` to kill it or change the port with `:lua LivePreview.config.port = <new_port>`"):format(
+							port,
+							process.name,
+							process.pid,
+							process.pid
+						),
+						vim.log.levels.WARN
+					)
+				end
 			end
 		end
 	end
@@ -83,7 +81,7 @@ function M.start(filepath, port)
 		},
 	})
 
-	return true
+	return true, M.serverObj.port
 end
 
 function M.pick()
@@ -97,11 +95,12 @@ function M.pick()
 		end
 		M.start(filepath, config.config.port)
 		vim.cmd.edit(filepath)
+		local actual_port = M.serverObj and M.serverObj.port or config.config.port
 		utils.open_browser(
 			string.format(
 				"http://%s:%d/%s",
 				config.config.address,
-				config.config.port,
+				actual_port,
 				config.config.dynamic_root and vim.fs.basename(filepath) or filepath
 			),
 			config.config.browser

--- a/lua/livepreview/server/init.lua
+++ b/lua/livepreview/server/init.lua
@@ -155,6 +155,8 @@ end
 --- 	- on_events (table<string, function(client:userdata, data:{filename: string, events: FsEvent}):void>)
 function Server:start(ip, port, opts)
 	self.server:bind(ip, port)
+	local sockname = self.server:getsockname()
+	self.port = sockname.port
 	local on_events = opts.on_events
 	if on_events then
 		if on_events.LivePreviewDirChanged then

--- a/plugin/livepreview.lua
+++ b/plugin/livepreview.lua
@@ -61,7 +61,8 @@ api.nvim_create_user_command(cmd, function(cmd_opts)
 		local urlpath = Config.dynamic_root and fs.basename(filepath)
 			or utils.get_relative_path(filepath, fs.normalize(vim.uv.cwd() or ""))
 		local urlpath_encoded = urlpath and vim.uri_encode(urlpath)
-		local url = ("http://%s:%d/%s"):format(Config.address, Config.port, urlpath_encoded)
+		local actual_port = lp.serverObj and lp.serverObj.port or Config.port
+		local url = ("http://%s:%d/%s"):format(Config.address, actual_port, urlpath_encoded)
 		print("live-preview.nvim: Opening browser at " .. url)
 		utils.open_browser(url, Config.browser)
 	elseif subcommand == "close" then


### PR DESCRIPTION
## What

Allows `port = 0` in config to auto-assign any free port. When port is 0:
- Skips the port-in-use check (meaningless for auto-assign)
- Reads back the actual assigned port via `uv_tcp_getsockname()`
- Uses the actual port in browser URLs instead of the config value

## Changes

- **server/init.lua** — call `getsockname()` after `bind()`, store `self.port`
- **lua/livepreview/init.lua** — wrap port-in-use check in `if port ~= 0`, return actual port from `start()`, use it in `pick()`
- **plugin/livepreview.lua** — use `lp.serverObj.port` for browser URL in `:LivePreview start`

## Why

Currently if port 8080 (or any fixed port) is in use by another process, the only options are to kill that process or change to a different hardcoded port. With `port = 0` the OS picks a free port automatically, no conflict ever.