### PR TITLE
fix: superfluous error log on Windows

### DIFF
--- a/lua/livepreview/utils.lua
+++ b/lua/livepreview/utils.lua
@@ -283,7 +283,7 @@ function M.processes_listening_on_port(port)
 	local cmd = ("lsof -i:%d | grep LISTEN | awk '{print $1, $2}'"):format(port)
 	if vim.uv.os_uname().version:match("Windows") then
 		cmd = ([[
-			Get-NetTCPConnection -LocalPort %d | Where-Object { $_.State -eq 'Listen' } | ForEach-Object {
+			Get-NetTCPConnection | Where-Object { $_.LocalPort -eq %d -and $_.State -eq 'Listen' } | ForEach-Object {
 				$procID = $_.OwningProcess
 				$process = Get-Process -Id $procID -ErrorAction SilentlyContinue
 				if ($process) {


### PR DESCRIPTION
Fixes #373.
Filter the processes by port after the call to Get-NetTCPConnection, since it causes to raise an error when no process is listening on the given port.