### PR TITLE
fix: close HTTP sockets after responding

### DIFF
--- a/lua/livepreview/server/handler.lua
+++ b/lua/livepreview/server/handler.lua
@@ -41,6 +41,18 @@ function M.send_http_response(client, status, content_type, body, headers)
 	response = response .. "\r\n" .. body
 
 	client:write(response)
+
+	-- M.client has already called read_stop(), so the EOF branch that would
+	-- close this socket can never fire: without an explicit close every request
+	-- leaks a descriptor in CLOSE_WAIT until the process hits EMFILE.
+	-- shutdown() rather than close() so the queued body is not truncated.
+	if not client:is_closing() then
+		client:shutdown(function()
+			if not client:is_closing() then
+				client:close()
+			end
+		end)
+	end
 end
 
 --- Handle an HTTP request

--- a/lua/livepreview/server/init.lua
+++ b/lua/livepreview/server/init.lua
@@ -61,6 +61,20 @@ local function send_scroll()
 	need_scroll = false
 end
 
+--- Drop a client from the broadcast list and close its socket
+--- @param client uv_tcp_t: client connection
+function M.forget_client(client)
+	for i, c in ipairs(M.connecting_clients) do
+		if c == client then
+			table.remove(M.connecting_clients, i)
+			break
+		end
+	end
+	if not client:is_closing() then
+		client:close()
+	end
+end
+
 --- Constructor
 --- @param webroot string|nil: path to the webroot
 function Server:new(webroot)
@@ -192,12 +206,7 @@ function Server:start(ip, port, opts)
 		handler.client(client, function(error, request)
 			if error or not request then
 				vim.notify(error and error, vim.log.levels.ERROR)
-				for i, c in ipairs(M.connecting_clients) do
-					if c == client then
-						client:close()
-						table.remove(M.connecting_clients, i)
-					end
-				end
+				M.forget_client(client)
 				return
 			else
 				local req_info = handler.request(client, request)
@@ -206,17 +215,34 @@ function Server:start(ip, port, opts)
 					local if_none_match = req_info.if_none_match
 					local accept = req_info.accept
 					local file_path = self:routes(path)
+					-- serve_file closes the connection once the response is sent
 					handler.serve_file(client, file_path, if_none_match, accept)
+				elseif not client:is_closing() then
+					-- handler.request returns nil only after a WebSocket
+					-- upgrade, and broadcasts must reach nothing else.
+					table.insert(M.connecting_clients, client)
+					-- Reads were stopped once the upgrade request was buffered,
+					-- so a closed tab would go unnoticed. Clients never send
+					-- frames upstream, so any read event means it is over.
+					client:read_start(function(read_err, chunk)
+						if read_err or not chunk then
+							M.forget_client(client)
+						end
+					end)
 				end
 			end
 		end)
-		table.insert(M.connecting_clients, client)
 	end)
 end
 
 --- Stop the server
 --- @param callback? function: callback to run after the server is stopped
 function Server:stop(callback)
+	-- Closing the listener alone leaves the still-open WebSocket sockets
+	-- behind, holding their file descriptors until Neovim exits.
+	for i = #M.connecting_clients, 1, -1 do
+		M.forget_client(M.connecting_clients[i])
+	end
 	if self.server then
 		self.server:close(function()
 			self.server = nil


### PR DESCRIPTION
## What

Every HTTP request leaks a file descriptor.

`handler.client` calls `read_stop()` as soon as a request is buffered, so the EOF branch that would close the socket never runs.

`send_http_response` only writes, and never closes either. The sockets sit in `CLOSE_WAIT` until the process dies.

## Why it matters

A markdown page load is about 10 requests: the file itself, plus the katex, mermaid, highlight and markdown-it assets.

macOS defaults to 256 descriptors, so a normal editing session reaches the limit in an afternoon.

Past that point the server stops accepting connections, and `processes_listening_on_port` throws `EMFILE` out of `vim.system`.

It also snowballs. `ws-client.js` reloads the page whenever its socket drops, and retries every second. Each reload is another 10 requests.

## How

**HTTP.** Close the socket in `send_http_response` once the write drains. `shutdown()` rather than `close()`, otherwise large responses get truncated.

**WebSocket.** Same cause: reads stop after the upgrade, so a closed tab is never noticed. Re-arm reads purely to watch for EOF.

Two related fixes while in here:

- `connecting_clients` now only holds WebSocket clients. It exists to broadcast WebSocket frames, but every accepted socket was added to it, so `send_json` was writing frames into plain HTTP connections.

- `Server:stop` closes the remaining clients, instead of leaving their descriptors open until Neovim exits.

## Evidence

Load only this plugin, start a server on 5701, then:

```sh
for i in $(seq 1 60); do
  curl -s -o /dev/null http://127.0.0.1:5701/index.md
done
lsof -p $PID | grep IPv4 | awk '{print $NF}' | sort | uniq -c
```

| | sockets after 60 requests |
| --- | --- |
| without the fix | 60 `CLOSE_WAIT` + 1 `LISTEN` | | with the fix | 1 `LISTEN` |

No regressions found: a 892KB markdown file still comes back whole (914542 bytes, closing `</html>` intact), and four WebSockets stay open while connected, then get reaped once the peers disconnect.